### PR TITLE
Fix spawning the Kotlin compiler in a path with spaces on Windows

### DIFF
--- a/packages/kotlinc-js-api/kotlin-compiler.js
+++ b/packages/kotlinc-js-api/kotlin-compiler.js
@@ -1,5 +1,5 @@
 'use strict';
-const spawn = require('child_process').spawn;
+const spawn = require('cross-spawn').spawn;
 const isWindows = /^win/.test(process.platform);
 
 function addOptionWithValue(options, optionName, optionValue) {

--- a/packages/kotlinc-js-api/package.json
+++ b/packages/kotlinc-js-api/package.json
@@ -23,6 +23,7 @@
   "author": "Andrey Skladchikov <andrey.skladchikov@gmail.com>",
   "license": "Apache-2.0",
   "dependencies": {
+    "cross-spawn": "^5.1.0",
     "kotlin-compiler": "^1.2.1"
   }
 }


### PR DESCRIPTION
On Windows, when spawning a command with spaces or passing arguments
with spaces, they have to be wrapped in double quotes, and Node.js
doesn't do this automatically. The cross-spawn wrapper for
child_process.spawn does.