### PR TITLE
Update globby usage in kotlin-webpack-plugin allowing multiple srcs to be passed.

### DIFF
--- a/packages/kotlin-webpack-plugin/plugin.js
+++ b/packages/kotlin-webpack-plugin/plugin.js
@@ -41,6 +41,7 @@ class KotlinWebpackPlugin {
     this.startTime = Date.now();
     this.prevTimestamps = {};
     this.initialRun = true;
+    this.sources = [].concat(this.options.src);
   }
 
   log(...args) {
@@ -98,7 +99,7 @@ class KotlinWebpackPlugin {
       .compile(
         Object.assign({}, this.options, {
           output: this.outputPath,
-          sources: [].concat(this.options.src),
+          sources: this.sources,
           moduleKind: 'commonjs',
           noWarn: true,
           verbose: false,
@@ -112,8 +113,8 @@ class KotlinWebpackPlugin {
   }
 
   watchKotlinSources(compilation, done) {
-    globby(['**/*.kt'], {
-      cwd: this.options.src,
+    const patterns = this.sources.map(it => it + '/**/*.kt');
+    globby(patterns, {
       absolute: true,
     }).then(paths => {
       const normalizedPaths = paths.map(it => path.normalize(it));


### PR DESCRIPTION
Current version (`1.2.1`) of `kotlin-webpack-plugin` fails when dev configuration passes multiple source directories:

In `webpack.config.dev.js`:
```
new KotlinWebpackPlugin({
  src: [paths.srcFoo, paths.srcBar],
  ...
}
```

After starting the app, it fails with:
```
TypeError: Path must be a string. 
```