### PR TITLE
Handle an experimental option with multi-platform flag

### DIFF
--- a/packages/kotlinc-js-api/kotlin-compiler.js
+++ b/packages/kotlinc-js-api/kotlin-compiler.js
@@ -56,6 +56,12 @@ function convertOptionsIntoArguments(options) {
     );
   }
 
+  if (options.experimental) {
+    if (options.experimental.multiPlatform) {
+      argumentsList = argumentsList.concat('-Xmulti-platform');
+    }
+  }
+
   argumentsList = argumentsList.concat(options.sources);
 
   return argumentsList.filter(arg => !!arg);


### PR DESCRIPTION
When code that uses experimental feature is compiled it will fail with:
```
error: the feature "multi platform projects" is experimental and should be enabled explicitly
```
But it seems there's no way to enable it explicitly. 

So this code should give this option, usage:
```
new KotlinWebpackPlugin({
  experimental: {
    multiPlatform: true
  },
  ...
})
```

It's also a convenient approach if there's a need of adding more experimental options.