### PR TITLE
Allow ts2kt-automator to run globally

### DIFF
--- a/packages/ts2kt-automator/lib.js
+++ b/packages/ts2kt-automator/lib.js
@@ -24,8 +24,8 @@ function spawnChildProcess(command, args) {
     });
 
     proc.on('close', (code) => {
-      if (code !== 0 && errors.length) {
-        return reject(errors.join(''));
+      if (code !== 0) {
+        return errors.join('') | `Error. \`${command} ${args.join(' ')}\` exited with code=${code}`;
       }
       resolve();
     });

--- a/packages/ts2kt-automator/lib.js
+++ b/packages/ts2kt-automator/lib.js
@@ -25,7 +25,8 @@ function spawnChildProcess(command, args) {
 
     proc.on('close', (code) => {
       if (code !== 0) {
-        return errors.join('') | `Error. \`${command} ${args.join(' ')}\` exited with code=${code}`;
+        const errorMessage = errors.join('') || `Error. \`${command} ${args.join(' ')}\` exited with code=${code}`;
+        return reject(errorMessage)
       }
       resolve();
     });

--- a/packages/ts2kt-automator/lib.js
+++ b/packages/ts2kt-automator/lib.js
@@ -43,7 +43,7 @@ function getPackageVersion(packageName) {
 }
 
 function getPackageTypeFilePath(name) {
-  const typePackage = require(`@types/${name}/package.json`);
+  const typePackage = require(path.resolve(process.cwd(), `./node_modules/@types/${name}/package.json`));
   // Looks like types packages always have just index.d.ts file
   // See https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package
   const typesFileName = typePackage.typings || 'index.d.ts';
@@ -59,7 +59,7 @@ function getPackageTypeFilePath(name) {
 
   console.log("Looks like package has embedded types. Let's check...");
 
-  const packageItself = require(`${name}/package.json`);
+  const packageItself = require(path.resolve(process.cwd(), `./node_modules/${name}/package.json`));
   if (!packageItself.typings) {
     throw new Error(
       `Cannot find types for package ${name}. It has no types in @types/${name} and no "typings" field in package.json`


### PR DESCRIPTION
After this fix ts2kt-automator should be able to run globally. Also fixed error handling in case a process exited with an error but without any error message.
Couldn't test it on so-called "packages with embedded types".