### PR TITLE
 timestamps in map instead of object

### DIFF
--- a/packages/kotlin-webpack-plugin/plugin.js
+++ b/packages/kotlin-webpack-plugin/plugin.js
@@ -108,8 +108,8 @@ class KotlinWebpackPlugin {
   }
 
   compileIfKotlinFilesChanged(compilation, done) {
-    const changedFiles = Object.keys(compilation.fileTimestamps).filter(
-      watchfile => (this.prevTimestamps[watchfile] || this.startTime) < (compilation.fileTimestamps[watchfile] || Infinity)
+    const changedFiles = Array.from(compilation.fileTimestamps.keys()).filter(
+      watchfile => (this.prevTimestamps.get(watchfile) || this.startTime) < (compilation.fileTimestamps.get(watchfile) || Infinity)
     );
 
     this.prevTimestamps = compilation.fileTimestamps;

--- a/packages/kotlin-webpack-plugin/plugin.js
+++ b/packages/kotlin-webpack-plugin/plugin.js
@@ -78,7 +78,7 @@ class KotlinWebpackPlugin {
     this.setPastDate = this.setPastDate.bind(this);
 
     this.startTime = Date.now();
-    this.prevTimestamps = {};
+    this.prevTimestamps = new Map();
     this.initialRun = true;
     this.sources = [].concat(this.options.src);
   }
@@ -109,9 +109,7 @@ class KotlinWebpackPlugin {
 
   compileIfKotlinFilesChanged(compilation, done) {
     const changedFiles = Object.keys(compilation.fileTimestamps).filter(
-      watchfile =>
-        (this.prevTimestamps[watchfile] || this.startTime) <
-        (compilation.fileTimestamps[watchfile] || Infinity)
+      watchfile => (this.prevTimestamps[watchfile] || this.startTime) < (compilation.fileTimestamps[watchfile] || Infinity)
     );
 
     this.prevTimestamps = compilation.fileTimestamps;


### PR DESCRIPTION
Hi,

I'm not following webpack development that closely, so I'm not sure if they at some point switched to Map instead of Object. Nevertheless this fix helped me with auto-recompilation on my setup. Maybe someone will find it useful as well.