### PR TITLE
Update fsevents to 1.2.4 for node 10

### DIFF
--- a/packages/gen-idea-libs/generate.js
+++ b/packages/gen-idea-libs/generate.js
@@ -45,7 +45,12 @@ module.exports = function generate(packages, projectDir, imlPath) {
     const classes = path.relative(projectDir, path.join(pkg, '..'));
     fs.writeFile(
       path.join(projectDir, `.idea/libraries/${name.replace(/-/g, '_')}.xml`),
-      libTemplate.replace(/%name%/g, name).replace(/%classes%/g, classes)
+      libTemplate.replace(/%name%/g, name).replace(/%classes%/g, classes),
+      err => {
+        if (err) {
+          throw err;
+        }
+      }
     );
 
     const dep = depTemplate.replace(/%name%/g, name);

--- a/packages/react-scripts/package.json
+++ b/packages/react-scripts/package.json
@@ -58,6 +58,6 @@
     "whatwg-fetch": "2.0.4"
   },
   "optionalDependencies": {
-    "fsevents": "1.1.3"
+    "fsevents": "1.2.4"
   }
 }


### PR DESCRIPTION
Further fix to resolve https://youtrack.jetbrains.com/issue/CRKA-81

Dependency for fsevents had to be bumped up to 1.2.4 to resolve deprecated build issues mentioned in CRKA-81.