### PR TITLE
kotlin-webpack-plugin now works with webpack 4

### DIFF
--- a/packages/kotlin-webpack-plugin/README.md
+++ b/packages/kotlin-webpack-plugin/README.md
@@ -8,6 +8,9 @@ This package allows compiling [Kotlin](https://kotlinlang.org/) files to JavaScr
 npm i @jetbrains/kotlin-webpack-plugin --save-dev
 ```
 
+## Requirements
+This plugin requires a minimum of Node v8.6.0 and Webpack v4.0.0. To use this plugin with Webpack v3.0.0, you need to use v1.2.11 of this plugin.
+
 ## Usage
 
 Example of webpack configuration:

--- a/packages/kotlin-webpack-plugin/package.json
+++ b/packages/kotlin-webpack-plugin/package.json
@@ -30,7 +30,8 @@
     "fs-extra": "^7.0.0",
     "glob": "^7.1.3",
     "globby": "^8.0.1",
-    "kotlin-compiler": "^1.3.0"
+    "kotlin-compiler": "^1.3.0",
+    "webpack-log": "^2.0.0"
   },
   "devDependencies": {
     "html-webpack-plugin": "^3.2.0",

--- a/packages/kotlin-webpack-plugin/package.json
+++ b/packages/kotlin-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jetbrains/kotlin-webpack-plugin",
-  "version": "1.2.11",
+  "version": "2.0.0",
   "description": "Kotlin plugin for webpack",
   "main": "plugin.js",
   "repository": "JetBrains/create-react-kotlin-app",

--- a/packages/kotlin-webpack-plugin/package.json
+++ b/packages/kotlin-webpack-plugin/package.json
@@ -16,7 +16,7 @@
     "Kotlin"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8.6.0"
   },
   "author": "Andrey Skladchikov <andrey.skladchikov@gmail.com>",
   "license": "Apache-2.0",

--- a/packages/kotlin-webpack-plugin/plugin.js
+++ b/packages/kotlin-webpack-plugin/plugin.js
@@ -1,4 +1,3 @@
-'use strict';
 const kotlinCompiler = require('@jetbrains/kotlinc-js-api');
 const globby = require('globby');
 const fs = require('fs-extra');
@@ -15,6 +14,7 @@ function getDefaultPackagesContents() {
   }
 }
 
+const pluginName = 'Kotlin Plugin';
 const DEFAULT_OPTIONS = {
   src: null, // An array or string with sources path
   output: 'kotlin_build',
@@ -29,38 +29,11 @@ const DEFAULT_OPTIONS = {
   optimize: false,
 };
 
-function prepareLibraries(opts) {
-  if (opts.librariesAutoLookup) {
-    if (opts.libraries.length > 0) {
-      console.warn(
-        'KotlinWebpackPlugin: "libraries" option is ignored because "librariesAutoLookup" option is enabled'
-      );
-    }
-
-    opts.libraries = librariesLookup.lookupKotlinLibraries(
-      opts.packagesContents
-    );
-    if (opts.verbose) {
-      console.info(
-        `>>> Kotlin Plugin: >>> autolookup found the following Kotlin libs:
-         ${opts.libraries.join('\n')}`
-      );
-    }
-  }
-
-  return Object.assign({}, opts, {
-    libraries: opts.libraries.map(main =>
-      main.replace(/(?:\.js)?$/, '.meta.js')
-    ),
-    librariesMainFiles: opts.libraries,
-  });
-}
-
 class KotlinWebpackPlugin {
   constructor(options) {
     const opts = Object.assign({}, DEFAULT_OPTIONS, options);
-
-    this.options = prepareLibraries(opts);
+    this.prepareLibraries = this.prepareLibraries.bind(this);
+    this.options = this.prepareLibraries(opts);
 
     this.outputPath = path.resolve(
       `${this.options.output}/${this.options.moduleName}.js`
@@ -77,27 +50,51 @@ class KotlinWebpackPlugin {
     );
     this.optimizeDeadCode = this.optimizeDeadCode.bind(this);
     this.setPastDate = this.setPastDate.bind(this);
-    this.log = this.log.bind(this);
 
     this.startTime = Date.now();
-    this.prevTimestamps = {};
+    this.prevTimestamps = new Map();
     this.initialRun = true;
     this.sources = [].concat(this.options.src);
 
-    this.logger = log({ name: 'Kotlin Plugin' });
-  }
-
-  log(...args) {
-    if (this.options.verbose) {
-      this.logger.info(...args);
-    }
+    const logLevel = !opts.verbose ? 'silent' : 'info';
+    this.log = log({ name: pluginName, level: logLevel });
   }
 
   apply(compiler) {
-    compiler.plugin('before-compile', this.compileIfFirstRun);
-    compiler.plugin('compilation', this.reportFirstCompilationError);
-    compiler.plugin('make', this.compileIfKotlinFilesChanged);
-    compiler.plugin('emit', this.watchKotlinSources);
+    compiler.hooks.beforeCompile.tapAsync(pluginName, this.compileIfFirstRun);
+    compiler.hooks.compilation.tap(
+      pluginName,
+      this.reportFirstCompilationError
+    );
+    compiler.hooks.make.tapAsync(pluginName, this.compileIfKotlinFilesChanged);
+    compiler.hooks.emit.tapAsync(pluginName, this.watchKotlinSources);
+  }
+
+  prepareLibraries(opts) {
+    if (opts.librariesAutoLookup) {
+      if (opts.libraries.length > 0) {
+        this.log.warn(
+          '"libraries" option is ignored because "librariesAutoLookup" option is enabled'
+        );
+      }
+
+      opts.libraries = librariesLookup.lookupKotlinLibraries(
+        opts.packagesContents
+      );
+
+      this.log.info(
+        `Autolookup found the following Kotlin libs:
+       ${opts.libraries.join('\n')}`
+      );
+    }
+
+    return {
+      ...opts,
+      libraries: opts.libraries.map(main =>
+        main.replace(/(?:\.js)?$/, '.meta.js')
+      ),
+      librariesMainFiles: opts.libraries,
+    };
   }
 
   copyLibraries() {
@@ -111,7 +108,7 @@ class KotlinWebpackPlugin {
     );
   }
 
-  compileIfKotlinFilesChanged(compilation, done) {
+  async compileIfKotlinFilesChanged(compilation, done) {
     const changedFiles = Array.from(compilation.fileTimestamps.keys()).filter(
       watchfile =>
         (this.prevTimestamps.get(watchfile) || this.startTime) <
@@ -125,77 +122,79 @@ class KotlinWebpackPlugin {
       return;
     }
 
-    this.log(
+    this.log.info(
       `Compiling Kotlin sources because the following files were changed: ${changedFiles.join(
         ', '
       )}`
     );
-    this.compileKotlinSources()
-      .then(done)
-      .catch(err => {
-        compilation.errors.push(err);
-        done();
-      });
-  }
 
-  compileKotlinSources() {
-    return kotlinCompiler
-      .compile(
-        Object.assign({}, this.options, {
-          output: this.outputPath,
-          sources: this.sources,
-          moduleKind: 'commonjs',
-          noWarn: true,
-          verbose: false,
-        })
-      )
-      .then(() => {
-        if (this.options.optimize) {
-          return this.optimizeDeadCode();
-        }
-      });
-  }
-
-  watchKotlinSources(compilation, done) {
-    const patterns = this.sources.map(it => it + '/**/*.kt');
-    globby(patterns, {
-      absolute: true,
-    }).then(paths => {
-      const normalizedPaths = paths.map(it => path.normalize(it));
-      if (compilation.fileDependencies.add) {
-        for (const path of normalizedPaths) {
-          compilation.fileDependencies.add(path);
-        }
-      } else {
-        // Before Webpack 4 - fileDepenencies was an array
-        compilation.fileDependencies.push(...normalizedPaths);
-      }
+    try {
+      await this.compileKotlinSources();
+    } catch (e) {
+      compilation.errors.push(e);
+    } finally {
       done();
+    }
+  }
+
+  async compileKotlinSources() {
+    await kotlinCompiler.compile({
+      ...this.options,
+      output: this.outputPath,
+      sources: this.sources,
+      moduleKind: 'commonjs',
+      noWarn: true,
+      verbose: false,
     });
+
+    if (this.options.optimize) {
+      return this.optimizeDeadCode();
+    }
   }
 
-  compileIfFirstRun(compilationParams, done) {
+  async watchKotlinSources(compilation, done) {
+    const patterns = this.sources.map(it => `${it}/**/*.kt`);
+    const paths = await globby(patterns, {
+      absolute: true,
+    });
+
+    const normalizedPaths = paths.map(it => path.normalize(it));
+
+    if (compilation.fileDependencies.add) {
+      for (const path of normalizedPaths) {
+        compilation.fileDependencies.add(path);
+      }
+    } else {
+      // Before Webpack 4 - fileDepenencies was an array
+      compilation.fileDependencies.push(...normalizedPaths);
+    }
+
+    done();
+  }
+
+  async compileIfFirstRun(params, done) {
     if (!this.initialRun) {
-      done();
-      return;
+      return done();
     }
 
     this.initialRun = false;
 
-    this.log('Initial compilation of Kotlin sources...');
-    this.compileKotlinSources()
-      .then(() => {
-        if (!this.options.optimize) {
-          return this.copyLibraries();
-        }
-      })
-      .then(this.setPastDate)
-      .then(done)
-      .catch(err => {
-        this.generateErrorBundle(err.toString());
-        this.firstCompilationError = err;
-        done();
-      });
+    this.log.info('Initial compilation of Kotlin sources...');
+
+    try {
+      await this.compileKotlinSources();
+
+      if (!this.options.optimize) {
+        await this.copyLibraries();
+      }
+
+      await this.setPastDate();
+    } catch (e) {
+      this.generateErrorBundle(e.toString());
+      this.firstCompilationError = e;
+    } finally {
+      done();
+    }
   }
 
   reportFirstCompilationError(compilation) {
@@ -206,10 +205,11 @@ class KotlinWebpackPlugin {
   }
 
   optimizeDeadCode() {
-    this.log(
+    this.log.info(
       `Optimizing Kotlin runtime... \nLibraries:`,
       this.options.librariesMainFiles.join('\n')
     );
+
     return DCEPlugin.optimize({
       outputDir: this.options.output,
       outputPath: this.outputPath,
@@ -217,27 +217,16 @@ class KotlinWebpackPlugin {
     });
   }
 
-  setPastDate() {
-    //Hack around multiple recompilations on start: set past modify date
+  async setPastDate() {
+    // Hack around multiple recompilations on start: set past modify date
     const timestamp = 100;
     const output = this.options.output;
 
-    return (
-      fs
-        .readdir(output)
-        .then(files =>
-          Promise.all(
-            files.map(file => {
-              return fs.utimes(
-                path.resolve(output, file),
-                timestamp,
-                timestamp
-              );
-            })
-          )
-        )
-        // discard the value
-        .then(() => {})
+    const files = await fs.readdir(output);
+    await Promise.all(
+      files.map(file =>
+        fs.utimes(path.resolve(output, file), timestamp, timestamp)
+      )
     );
   }
 
@@ -247,7 +236,7 @@ class KotlinWebpackPlugin {
       `${this.options.moduleName}.js`
     );
 
-    this.log('Generating error entry', file);
+    this.log.info('Generating error entry', file);
 
     if (!fs.existsSync(this.options.output)) {
       fs.mkdirSync(this.options.output);

--- a/packages/kotlin-webpack-plugin/plugin.js
+++ b/packages/kotlin-webpack-plugin/plugin.js
@@ -3,6 +3,7 @@ const kotlinCompiler = require('@jetbrains/kotlinc-js-api');
 const globby = require('globby');
 const fs = require('fs-extra');
 const path = require('path');
+const log = require('webpack-log');
 const DCEPlugin = require('./dce-plugin');
 const librariesLookup = require('./libraries-lookup');
 
@@ -76,16 +77,19 @@ class KotlinWebpackPlugin {
     );
     this.optimizeDeadCode = this.optimizeDeadCode.bind(this);
     this.setPastDate = this.setPastDate.bind(this);
+    this.log = this.log.bind(this);
 
     this.startTime = Date.now();
     this.prevTimestamps = {};
     this.initialRun = true;
     this.sources = [].concat(this.options.src);
+
+    this.logger = log({ name: 'Kotlin Plugin' });
   }
 
   log(...args) {
     if (this.options.verbose) {
-      console.info('>>> Kotlin Plugin: >>>', ...args);
+      this.logger.info(...args);
     }
   }
 
@@ -243,9 +247,7 @@ class KotlinWebpackPlugin {
       `${this.options.moduleName}.js`
     );
 
-    if (this.options.verbose) {
-      console.log('>>> Kotlin Plugin: >>> generating error entry', file);
-    }
+    this.log('Generating error entry', file);
 
     if (!fs.existsSync(this.options.output)) {
       fs.mkdirSync(this.options.output);

--- a/packages/kotlin-webpack-plugin/plugin.js
+++ b/packages/kotlin-webpack-plugin/plugin.js
@@ -108,10 +108,10 @@ class KotlinWebpackPlugin {
   }
 
   compileIfKotlinFilesChanged(compilation, done) {
-    const changedFiles = Object.keys(compilation.fileTimestamps).filter(
+    const changedFiles = Array.from(compilation.fileTimestamps.keys()).filter(
       watchfile =>
-        (this.prevTimestamps[watchfile] || this.startTime) <
-        (compilation.fileTimestamps[watchfile] || Infinity)
+        (this.prevTimestamps.get(watchfile) || this.startTime) <
+        (compilation.fileTimestamps.get(watchfile) || Infinity)
     );
 
     this.prevTimestamps = compilation.fileTimestamps;


### PR DESCRIPTION
* Fix for compileIfKotlinFilesChanged. Webpack now uses Map instead Object in compilation.fileTimestamps.
* Use webpack-log instead custom log function.
* Moved to new webpack 4 api for hooks.
* Minimal supported nodejs version to 8.6.0
* Code improvements.
* 2.0.0

Fix for issue: https://youtrack.jetbrains.com/issue/CRKA-94