### PR TITLE
Update KotlinWebpackPlugin not to error if output path is nested

### DIFF
--- a/packages/kotlin-webpack-plugin/plugin.js
+++ b/packages/kotlin-webpack-plugin/plugin.js
@@ -246,7 +246,7 @@ class KotlinWebpackPlugin {
     this.log.info('Generating error entry', file);
 
     if (!fs.existsSync(this.options.output)) {
-      fs.mkdirSync(this.options.output);
+      fs.mkdirSync(this.options.output, {recursive: true});
     }
 
     const message = `throw new Error("Failed to compile Kotlin code: ${(


### PR DESCRIPTION
I stumbled on an issue using CRKA and the [mars/create-react-app Heroku buildpack](https://github.com/mars/create-react-app-buildpack) trying to deploy a freshly created project to Heroku. The build fails because the plugin is attempting to write to the directory `/tmp/build_XXX/node_modules/.cache/kotlin-webpack` which doesn't yet exist.

I believe that this simple change should handle the creation of the `.cache` directory if it doesn't yet exist. The build is working on my local machine and I'm not sure how to easily test this change on Heroku (or reproduce a nested output like this in general) so I haven't tested it yet. It _should_ work the same as it is currently if the path isn't nested.

Here's the truncated build log:

```
-----> Creating runtime environment
       
       NPM_CONFIG_LOGLEVEL=error
       NODE_ENV=production
       NODE_MODULES_CACHE=false
       NODE_VERBOSE=false
       
-----> Installing binaries
       engines.node (package.json):  unspecified
       engines.npm (package.json):   unspecified (use default)
       
       Resolving node version 12.x...
       Downloading and installing node 12.13.0...
       Using default npm version: 6.12.0
       
-----> Restoring cache
       Caching has been disabled because NODE_MODULES_CACHE=false
       
-----> Installing dependencies
       Installing node modules (package.json + package-lock)
       
       > core-js@3.4.1 postinstall /tmp/build_f025ee36ba46646fd0b6ad74b8372591/node_modules/core-js
       > node postinstall || echo "ignore"
       
       
       > bloom-web@0.1.0 postinstall /tmp/build_f025ee36ba46646fd0b6ad74b8372591
       > npm run gen-idea-libs
       
       
       > bloom-web@0.1.0 gen-idea-libs /tmp/build_f025ee36ba46646fd0b6ad74b8372591
       > react-scripts-kotlin gen-idea-libs
       
       added 850 packages from 436 contributors and audited 9387 packages in 22.64s
       found 0 vulnerabilities
       
       
-----> Build
       Running build
       
       > bloom-web@0.1.0 build /tmp/build_f025ee36ba46646fd0b6ad74b8372591
       > react-scripts-kotlin build
       
       Creating an optimized production build...
/tmp/build_f025ee36ba46646fd0b6ad74b8372591/node_modules/react-scripts-kotlin/scripts/build.js:19
  throw err;
  ^
Error: ENOENT: no such file or directory, mkdir '/tmp/build_f025ee36ba46646fd0b6ad74b8372591/node_modules/.cache/kotlin-webpack'
    at Object.mkdirSync (fs.js:823:3)
    at KotlinWebpackPlugin.generateErrorBundle (/tmp/build_f025ee36ba46646fd0b6ad74b8372591/node_modules/@jetbrains/kotlin-webpack-plugin/plugin.js:249:10)
    at KotlinWebpackPlugin.compileIfFirstRun (/tmp/build_f025ee36ba46646fd0b6ad74b8372591/node_modules/@jetbrains/kotlin-webpack-plugin/plugin.js:199:12)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  errno: -2,
  syscall: 'mkdir',
  code: 'ENOENT',
  path: '/tmp/build_f025ee36ba46646fd0b6ad74b8372591/node_modules/.cache/kotlin-webpack'
}
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! bloom-web@0.1.0 build: `react-scripts-kotlin build`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the bloom-web@0.1.0 build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.
npm ERR! A complete log of this run can be found in:
npm ERR!     /tmp/npmcache.W9Dsr/_logs/2019-11-18T18_14_25_158Z-debug.log
-----> Build failed
```